### PR TITLE
Support the graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	flag.StringVar(&documentRoot, "documentRoot", "/workspace", "the document root of the file server")
 	flag.StringVar(&basePath, "basePath", "", "the url base path of the APIs")
-	flag.StringVar(&host, "host", "", "hostname")
+	flag.StringVar(&host, "host", "localhost", "hostname")
 	flag.StringVar(&port, "port", "33333", "port")
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"net"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/c9s/gomon/logger"
 	fs "github.com/hwchiu/fileserver/src"
@@ -41,8 +46,19 @@ func main() {
 
 	bind := net.JoinHostPort(host, port)
 	logger.Infof("Listening at %s", bind)
+	server := &http.Server{Addr: bind, Handler: logRequest(router)}
 
-	http.ListenAndServe(bind, logRequest(router))
+	sigC := make(chan os.Signal)
+	signal.Notify(sigC, syscall.SIGTERM)
+	go func() {
+		<-sigC
+		logger.Infof("caught signal SIGTERM, terminating fileserver...")
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		server.Shutdown(ctx)
+		os.Exit(0)
+	}()
+
+	server.ListenAndServe()
 }
 
 func logRequest(handler http.Handler) http.Handler {


### PR DESCRIPTION
- Add the default value `localhost` for `host` parameter
- Use the `context` and `signal` for graceful shutdown